### PR TITLE
Fix build-time dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,6 +24,8 @@ Depends:
     ggplot2
 Imports:
     isoband,
+    vctrs,
+    tibble,
     MASS,
     stats,
     scales

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## Fixes
 
+* Removed **ggplot2** build-time dependencies (Reported by @thomasp85, #21)
+
 * Fixed bug in `stat_hdr_lines_fun()` which drew lines between components of disconnected HDRs (Reported by @afranks86, #20)
 
 

--- a/R/helpers-ggplot2.R
+++ b/R/helpers-ggplot2.R
@@ -1,4 +1,5 @@
-# unexported functions from ggplot2 (move to their own .R file)
+# unexported functions from ggplot2
+
 `%||%` <- function(x, y) {
   if (is.null(x)) y else x
 }

--- a/R/helpers-ggplot2.R
+++ b/R/helpers-ggplot2.R
@@ -1,0 +1,82 @@
+# unexported functions from ggplot2 (move to their own .R file)
+`%||%` <- function(x, y) {
+  if (is.null(x)) y else x
+}
+
+tibble0 <- function(...) {
+  tibble::tibble(..., .name_repair = "minimal")
+}
+
+unique0 <- function(x, ...) {
+  if (is.null(x)) x else vctrs::vec_unique(x, ...)
+}
+
+isoband_z_matrix <- function(data) {
+  x_pos <- as.integer(factor(data$x, levels = sort(unique0(data$x))))
+  y_pos <- as.integer(factor(data$y, levels = sort(unique0(data$y))))
+  nrow <- max(y_pos)
+  ncol <- max(x_pos)
+  raster <- matrix(NA_real_, nrow = nrow, ncol = ncol)
+  raster[cbind(y_pos, x_pos)] <- data$z
+  raster
+}
+
+xyz_to_isobands <- function(data, breaks) {
+  isoband::isobands(x = sort(unique0(data$x)), y = sort(unique0(data$y)),
+                    z = isoband_z_matrix(data), levels_low = breaks[-length(breaks)],
+                    levels_high = breaks[-1])
+}
+
+xyz_to_isolines <- function(data, breaks) {
+  isoband::isolines(x = sort(unique0(data$x)), y = sort(unique0(data$y)),
+                    z = isoband_z_matrix(data), levels = breaks)
+}
+
+iso_to_polygon <- function(iso, group = 1) {
+  lengths <- vapply(iso, function(x) length(x$x), integer(1))
+  if (all(lengths == 0)) {
+    warning("Zero contours were generated")
+    return(tibble0())
+  }
+  levels <- names(iso)
+  xs <- unlist(lapply(iso, "[[", "x"), use.names = FALSE)
+  ys <- unlist(lapply(iso, "[[", "y"), use.names = FALSE)
+  ids <- unlist(lapply(iso, "[[", "id"), use.names = FALSE)
+  item_id <- rep(seq_along(iso), lengths)
+  groups <- paste(group, sprintf("%03d", item_id), sep = "-")
+  groups <- factor(groups)
+  tibble0(level = rep(levels, lengths), x = xs, y = ys,
+              piece = as.integer(groups), group = groups, subgroup = ids,
+              .size = length(xs))
+}
+
+iso_to_path <- function(iso, group = 1) {
+  lengths <- vapply(iso, function(x) length(x$x), integer(1))
+  if (all(lengths == 0)) {
+    warning("Zero contours were generated")
+    return(tibble0())
+  }
+  levels <- names(iso)
+  xs <- unlist(lapply(iso, "[[", "x"), use.names = FALSE)
+  ys <- unlist(lapply(iso, "[[", "y"), use.names = FALSE)
+  ids <- unlist(lapply(iso, "[[", "id"), use.names = FALSE)
+  item_id <- rep(seq_along(iso), lengths)
+  groups <- paste(group, sprintf("%03d", item_id), sprintf("%03d",
+                                                           ids), sep = "-")
+  groups <- factor(groups)
+  tibble0(level = rep(levels, lengths), x = xs, y = ys,
+              piece = as.integer(groups), group = groups, .size = length(xs))
+}
+
+empty <- function(df) {
+  is.null(df) || nrow(df) == 0 || ncol(df) == 0 || inherits(df, "waiver")
+}
+
+ensure_nonempty_data <- function(data) {
+  if (empty(data)) {
+    tibble0(group = 1, .size = 1)
+  }
+  else {
+    data
+  }
+}

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -1,33 +1,15 @@
 # this script contains several unexported helper functions
 
-`%||%` <- function(x, y) {
-  if (is.null(x)) y else x
-}
-
-
-# unexported functions from ggplot2
-xyz_to_isobands <- get("xyz_to_isobands", asNamespace("ggplot2"))
-xyz_to_isolines <- get("xyz_to_isolines", asNamespace("ggplot2"))
-iso_to_polygon <- get("iso_to_polygon", asNamespace("ggplot2"))
-iso_to_path <- get("iso_to_path", asNamespace("ggplot2"))
-ensure_nonempty_data <- get("ensure_nonempty_data", asNamespace("ggplot2"))
-
-
-
 # normalization/scaling functions
 normalize <- function(v) v / sum(v)
 standardize <- function(v, min = min(v), max = max(v)) (v - min) / (max - min)
 rescale <- function(v) v / max(v)
-
-
 
 # discrete approximation to P[f^(X,Y) >= c]
 prob_above_c <- function(df, c) {
   if (length(c) > 1) return(vapply(c, prob_above_c, df = df, numeric(1)))
   with(df, sum(fhat_discretized[fhat >= c]))
 }
-
-
 
 # numerical approximation for finding hdr
 # if method = "histogram", don't want to use uniroot, runs into issue if n is small
@@ -37,7 +19,7 @@ find_cutoff <- function(df, conf, uniroot = TRUE) {
 
   # the following is set to FALSE to override when other code calls
   # the function with uniroot = TRUE, remove once we're confident the
-  # code works in all cirumstances
+  # code works in all circumstances
   if (FALSE) {
 
     uniroot(function(c) prob_above_c(df, c) - conf, lower = 0, upper = 1)$root
@@ -56,4 +38,3 @@ find_cutoff <- function(df, conf, uniroot = TRUE) {
   }
 
 }
-


### PR DESCRIPTION
This PR ensures that **ggdensity** is passing with the new version of **ggplot2** (`tidyverse/ggplot2@v3.4.0-rc`), according to #21. The bug was caused by several instances of `get("foo", asNamespace("ggplot2"))` in `R/helpers.R`. These have been replaced with slightly modified code from **ggplot2**, now located in `R/helpers-ggplot2.R`, according to the strategy outlined in https://www.tidyverse.org/blog/2022/09/playing-on-the-same-team-as-your-dependecy/.