### PR TITLE
Fix `geom_hdr_rug()` invading guides

### DIFF
--- a/R/hdr_rug.R
+++ b/R/hdr_rug.R
@@ -92,7 +92,7 @@ stat_hdr_rug <- function(mapping = NULL, data = NULL,
                          ylim = NULL,
                          n = 512,
                          na.rm = FALSE,
-                         show.legend = TRUE,
+                         show.legend = NA,
                          inherit.aes = TRUE) {
   layer(
     data = data,
@@ -222,7 +222,7 @@ geom_hdr_rug <- function(mapping = NULL, data = NULL,
                          sides = "bl",
                          length = unit(0.03, "npc"),
                          na.rm = FALSE,
-                         show.legend = TRUE,
+                         show.legend = NA,
                          inherit.aes = TRUE) {
   layer(
     data = data,

--- a/R/hdr_rug_fun.R
+++ b/R/hdr_rug_fun.R
@@ -191,7 +191,7 @@ geom_hdr_rug_fun <- function(mapping = NULL, data = NULL,
                          sides = "bl",
                          length = unit(0.03, "npc"),
                          na.rm = FALSE,
-                         show.legend = TRUE,
+                         show.legend = NA,
                          inherit.aes = TRUE) {
 
   if (is.null(data)) data <- ensure_nonempty_data

--- a/man/geom_hdr_rug.Rd
+++ b/man/geom_hdr_rug.Rd
@@ -21,7 +21,7 @@ stat_hdr_rug(
   ylim = NULL,
   n = 512,
   na.rm = FALSE,
-  show.legend = TRUE,
+  show.legend = NA,
   inherit.aes = TRUE
 )
 
@@ -35,7 +35,7 @@ geom_hdr_rug(
   sides = "bl",
   length = unit(0.03, "npc"),
   na.rm = FALSE,
-  show.legend = TRUE,
+  show.legend = NA,
   inherit.aes = TRUE
 )
 }

--- a/man/geom_hdr_rug_fun.Rd
+++ b/man/geom_hdr_rug_fun.Rd
@@ -37,7 +37,7 @@ geom_hdr_rug_fun(
   sides = "bl",
   length = unit(0.03, "npc"),
   na.rm = FALSE,
-  show.legend = TRUE,
+  show.legend = NA,
   inherit.aes = TRUE
 )
 }


### PR DESCRIPTION
This PR aims to fix #18.

Briefly, when `show.legend = TRUE`,  the layer is displayed in a legend regardless of whether it has any mapped aesthetics. This caused the `geom_hdr_rug()`'s key to show up in the `alpha` guide, despite not mapping `alpha`. The fix is to set `show.legend = NA`, which is the default in most layers.

``` r
devtools::load_all("~/packages/ggdensity/")
#> ℹ Loading ggdensity
#> Loading required package: ggplot2

ggplot(cars, aes(speed, dist)) +
  geom_hdr() +
  geom_point(color = "red") +
  geom_hdr_rug(aes(fill = after_stat(probs)), length = unit(.2, "cm"), alpha = 1) +
  scale_fill_viridis_d(option = "magma", begin = .8, end = 0)
```

![](https://i.imgur.com/EepfV87.png)<!-- -->

<sup>Created on 2024-08-28 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
